### PR TITLE
Add enum for description

### DIFF
--- a/schemas/metadata/1.0.json
+++ b/schemas/metadata/1.0.json
@@ -62,8 +62,9 @@
 
             "propertyNames": {
                 "type": "string",
-                "description": "The language key. The key must be countrycode(_LANGUAGECODE).",
-                "pattern": "^[a-z]{2}(_[A-Z]{2})?$"
+                "description": "The language key. The key must be languagecode(_REGIONCODE).",
+                "pattern": "^[a-z]{2}(_[A-Z]{2})?$",
+                "enum": ["ar_SA","cs_CZ","da_DK","de","en","es","he_IL","nl","ja_JP","pt_BR","sv_SE","ro","tr","it","pl","sk","zh_CN","fr","hu","no","ru","uk_UA","fi","ko_KR","pt","th","bs_BA","id","sl_SI","az","vi_VN","et_EE","bn_BD","lt","uz","zh_TW","ga_IE","bg","fa_IR","is"]
             },
             "patternProperties": {
                 "^[a-z]{2}(_[A-Z]{2})?$": {


### PR DESCRIPTION
Oh, another thing.

I have added the enum/valid value set for the description, based on https://api.premid.app/v2/langFile/list. At first I'm not sure if this works, but it actually works.

This requires updating the schema every time a new language is added on the link above, but I don't think it will become a huge deal, hopefully.

Also, it is ``languagecode(_REGIONCODE)``, based on [this article](https://tools.ietf.org/html/bcp47#page-1-80).

So sorry for making another pull request.